### PR TITLE
Add new Ember driver.

### DIFF
--- a/charts/stable/zigbee2mqtt/questions.yaml
+++ b/charts/stable/zigbee2mqtt/questions.yaml
@@ -80,6 +80,8 @@ questions:
                                                     description: "ezsp"
                                                   - value: "zstack"
                                                     description: "zstack"
+                                                  - value: "ember"
+                                                    description: "ember"
 # Include{containerBasic}
 # Include{containerAdvanced}
 # Include{containerConfig}


### PR DESCRIPTION
A new driver has been released [https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.36.1](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.36.1), the current questions enum does not include the option to select it.